### PR TITLE
Aggregate case tables by material and show seasons

### DIFF
--- a/components/CaseTableTabs.jsx
+++ b/components/CaseTableTabs.jsx
@@ -5,15 +5,14 @@ import VerticalCarousel from "./VerticalCarousel";
  * CaseTableTabs Component
  *
  * Provides beautifully styled tabs, each containing a vertical carousel of cases for similar models.
- * Supports filtering by season, material, and multiple model series.
+ * Supports filtering by material and multiple model series.
  *
  * @param {string} series - The series of devices (e.g., "iPhone 16") to display in tabs.
- * @param {string} season - The season to filter cases (e.g., "Autumn 2020").
  * @param {string} material - The material of the case to filter cases (e.g., "Leather Case").
  * @param {Array<string>} [tabNames] - Custom names for the tabs (optional). Defaults to formatted model names.
- * @returns {JSX.Element} Tabs displaying vertical carousels for filtered cases.
+ * @returns {JSX.Element} Tabs displaying vertical carousels for filtered cases across all seasons.
  */
-const CaseTableTabs = ({ series, season, material, tabNames }) => {
+const CaseTableTabs = ({ series, material, tabNames }) => {
   // Pre-defined batches to expand series when it's "iPhone 16"
   let models;
   switch (series) {
@@ -92,7 +91,6 @@ const CaseTableTabs = ({ series, season, material, tabNames }) => {
         <Tabs.Tab key={index} title={model}>
           <VerticalCarousel
             {...(model ? { model } : {})}
-            {...(season ? { season } : {})}
             {...(material ? { material } : {})}
           />
         </Tabs.Tab>

--- a/components/VerticalCarousel.jsx
+++ b/components/VerticalCarousel.jsx
@@ -5,7 +5,7 @@ import { Table } from "nextra/components";
 import Link from "next/link";
 import Image from "next/image";
 
-function useCases(model, material, season) {
+function useCases(model, material) {
   const [cases, setCases] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -14,7 +14,6 @@ function useCases(model, material, season) {
     const params = new URLSearchParams();
     if (model) params.set("model", model);
     if (material) params.set("material", material);
-    if (season) params.set("season", season);
 
     setLoading(true);
     fetch(`/api/cases?${params.toString()}`)
@@ -32,13 +31,13 @@ function useCases(model, material, season) {
     return () => {
       aborted = true;
     };
-  }, [model, material, season]);
+  }, [model, material]);
 
   return { cases, loading };
 }
 
-const VerticalCarousel = ({ model, material, season }) => {
-  const { cases, loading } = useCases(model, material, season);
+const VerticalCarousel = ({ model, material }) => {
+  const { cases, loading } = useCases(model, material);
 
   const [isSmallViewport, setIsSmallViewport] = useState(false);
 
@@ -100,6 +99,12 @@ const VerticalCarousel = ({ model, material, season }) => {
             <Table.Tr>
               <Table.Td style={{ textAlign: "center", padding: "0" }}>
                 <span style={{ color: "#ccc" }}>SKU</span>
+              </Table.Td>
+            </Table.Tr>
+
+            <Table.Tr>
+              <Table.Td style={{ textAlign: "center", padding: "0" }}>
+                <span style={{ color: "#ccc" }}>Season</span>
               </Table.Td>
             </Table.Tr>
           </tbody>
@@ -192,6 +197,26 @@ const VerticalCarousel = ({ model, material, season }) => {
                   >
                     <span style={{ marginLeft: "4px", marginRight: "4px" }}>
                       {item.SKU + (isSmallViewport ? "ZM" : "ZM/A")}
+                    </span>
+                  </div>
+                </Table.Td>
+              ))}
+            </Table.Tr>
+
+            {/* Row 3: Season */}
+            <Table.Tr>
+              {cases.map((item) => (
+                <Table.Td key={item.SKU} style={{ padding: "0" }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      height: "50px",
+                    }}
+                  >
+                    <span style={{ marginLeft: "4px", marginRight: "4px" }}>
+                      {item.season || "—"}
                     </span>
                   </div>
                 </Table.Td>

--- a/content/iphone/11.mdx
+++ b/content/iphone/11.mdx
@@ -10,48 +10,24 @@ Staying true to tradition, the iPhone 11 series Silicone Case and Clear Case wer
 
 These cases are exclusive to iPhone 11 Pro & Pro Max; they won't fit iPhone X models.
 
-## Summer 2020 collection
+## Silicone Case
 
-### Silicone Case
+<CaseTableTabs series="iPhone 11 Pro" material="Silicone Case" />
 
-<CaseTableTabs series="iPhone 11 Pro" season="Summer 2020" material="Silicone Case" />
+## Leather Case
 
-## Spring 2020 collection
+<CaseTableTabs series="iPhone 11 Pro" material="Leather Case" />
 
-### Silicone Case
-
-<CaseTableTabs series="iPhone 11 Pro" season="Spring 2020" material="Silicone Case" />
-
-### Leather Folio
-
-<CaseTableTabs series="iPhone 11 Pro" season="Spring 2020" material="Leather Folio" />
+## Leather Folio
 
 Yes, Apple decided to only release these colors as Folios (:
 
-## November 2019 collection
-
-### Silicone Case
-
-<CaseTableTabs series="iPhone 11 Pro" season="November 2019" material="Silicone Case" />
-
-## Autumn 2019 collection
-
-### Silicone Case
-
-<CaseTableTabs series="iPhone 11 Pro" season="Autumn 2019" material="Silicone Case" />
-
-### Leather Case
-
-<CaseTableTabs series="iPhone 11 Pro" season="Autumn 2019" material="Leather Case" />
-
-### Leather Folio
-
-<CaseTableTabs series="iPhone 11 Pro" season="Autumn 2019" material="Leather Folio" />
+<CaseTableTabs series="iPhone 11 Pro" material="Leather Folio" />
 
 ## Smart Battery Case
 
-<CaseTableTabs series="iPhone 11 Pro" season="November 2019" material="Smart Battery Case" />
+<CaseTableTabs series="iPhone 11 Pro" material="Smart Battery Case" />
 
 ## Clear Case
 
-<CaseTableTabs series="iPhone 11 Pro" season="Autumn 2019" material="Clear Case" />
+<CaseTableTabs series="iPhone 11 Pro" material="Clear Case" />

--- a/content/iphone/12.mdx
+++ b/content/iphone/12.mdx
@@ -15,40 +15,18 @@ As has been the standard, the iPhone 12 Silicone Case and Clear Case were each l
 
 These cases are not compatible with similar-looking iPhone 13, just like iPhone 12 is not perfectly compatible with iPhone 13 cases.
 
-## Summer 2021 collection
+## Silicone Case
 
-### Silicone Case
+<CaseTableTabs series="iPhone 12" material="Silicone Case" />
 
-<CaseTableTabs series="iPhone 12" season="Summer 2021" material="Silicone Case" />
+## Leather Case
 
-## Spring 2021 collection
+<CaseTableTabs series="iPhone 12" material="Leather Case" />
 
-### Silicone Case
+## Leather Sleeve
 
-<CaseTableTabs series="iPhone 12" season="Spring 2021" material="Silicone Case" />
-
-### Leather Case
-
-<CaseTableTabs series="iPhone 12" season="Spring 2021" material="Leather Case" />
-
-### Leather Sleeve
-
-<CaseTableTabs series="iPhone 12" season="Spring 2021" material="Leather Sleeve" />
-
-## Autumn 2020 collection
-
-### Silicone Case
-
-<CaseTableTabs series="iPhone 12" season="Autumn 2020" material="Silicone Case" />
-
-### Leather Case
-
-<CaseTableTabs series="iPhone 12" season="Autumn 2020" material="Leather Case" />
-
-### Leather Sleeve
-
-<CaseTableTabs series="iPhone 12" season="Autumn 2020" material="Leather Sleeve" />
+<CaseTableTabs series="iPhone 12" material="Leather Sleeve" />
 
 ## Clear Case
 
-<CaseTableTabs series="iPhone 12" season="Autumn 2020" material="Clear Case" />
+<CaseTableTabs series="iPhone 12" material="Clear Case" />

--- a/content/iphone/13.mdx
+++ b/content/iphone/13.mdx
@@ -10,22 +10,14 @@ True to form, the iPhone 13 Silicone Case and Clear Case are priced at \$49, whi
 
 iPhone 13 models feature a slightly bigger camera bump, so they are not compatible with cases made for the iPhone 12.
 
-## Spring 2022 collection
+## Silicone Case
 
-### Silicone Case
+<CaseTableTabs series="iPhone 13" material="Silicone Case" />
 
-<CaseTableTabs series="iPhone 13" season="Spring 2022" material="Silicone Case" />
+## Leather Case
 
-## Autumn 2021 collection
-
-### Silicone Case
-
-<CaseTableTabs series="iPhone 13" season="Autumn 2021" material="Silicone Case" />
-
-### Leather Case
-
-<CaseTableTabs series="iPhone 13" season="Autumn 2021" material="Leather Case" />
+<CaseTableTabs series="iPhone 13" material="Leather Case" />
 
 ## Clear Case
 
-<CaseTableTabs series="iPhone 13" season="Autumn 2021" material="Clear Case" />
+<CaseTableTabs series="iPhone 13" material="Clear Case" />

--- a/content/iphone/14.mdx
+++ b/content/iphone/14.mdx
@@ -12,22 +12,14 @@ As it goes, the iPhone 14 Silicone Case and Clear Case will set you back \$49, w
 
 iPhone 14 models feature a slightly different button layout, so they are not compatible with cases made for the iPhone 13.
 
-## Spring 2023 collection
+## Silicone Case
 
-### Silicone Case
+<CaseTableTabs series="iPhone 14" material="Silicone Case" />
 
-<CaseTableTabs series="iPhone 14" season="Spring 2023" material="Silicone Case" />
+## Leather Case
 
-## Autumn 2022 collection
-
-### Silicone Case
-
-<CaseTableTabs series="iPhone 14" season="Autumn 2022" material="Silicone Case" />
-
-### Leather Case
-
-<CaseTableTabs series="iPhone 14" season="Autumn 2022" material="Leather Case" />
+<CaseTableTabs series="iPhone 14" material="Leather Case" />
 
 ## Clear Case
 
-<CaseTableTabs series="iPhone 14" season="Autumn 2022" material="Clear Case" />
+<CaseTableTabs series="iPhone 14" material="Clear Case" />

--- a/content/iphone/15.mdx
+++ b/content/iphone/15.mdx
@@ -14,22 +14,14 @@ In the usual fashion, iPhone 15 Silicone Case and Clear Case are priced at \$49 
 
 iPhone 15 models features curvier corners than previous models, so cases made for iPhone 15 series are only compatible with corresponding iPhone 15.
 
-## Spring 2024 Collection
+## Silicone Case
 
-### Silicone Case
+<CaseTableTabs series="iPhone 15" material="Silicone Case" />
 
-<CaseTableTabs series="iPhone 15" season="Spring 2024" material="Silicone Case" />
+## FineWoven Case
 
-## Autumn 2023 Collection
-
-### Silicone Case
-
-<CaseTableTabs series="iPhone 15" season="Autumn 2023" material="Silicone Case" />
-
-### FineWoven Case
-
-<CaseTableTabs series="iPhone 15" season="Autumn 2023" material="FineWoven Case" />
+<CaseTableTabs series="iPhone 15" material="FineWoven Case" />
 
 ## Clear Case
 
-<CaseTableTabs series="iPhone 15" season="Autumn 2023" material="Clear Case" />
+<CaseTableTabs series="iPhone 15" material="Clear Case" />

--- a/content/iphone/16.mdx
+++ b/content/iphone/16.mdx
@@ -10,16 +10,14 @@ This time, every accessory comes in \$49, including Silicone Case, Clear Case, a
 
 iPhone 16 Pro models features different size compared to 15 Pro, and iPhone 16 features different camera layout compared to 15, so these cases won't fit previous models.
 
-## Autumn 2024 Collection
+## Silicone Case
 
-### Silicone Case
+<CaseTableTabs series="iPhone 16" material="Silicone Case" />
 
-<CaseTableTabs series="iPhone 16" season="Autumn 2024" material="Silicone Case" />
+## Beats Case
 
-### Beats Case
-
-<CaseTableTabs series="iPhone 16" season="Autumn 2024" material="Beats Case" />
+<CaseTableTabs series="iPhone 16" material="Beats Case" />
 
 ## Clear Case
 
-<CaseTableTabs series="iPhone 16" season="Autumn 2024" material="Clear Case" />
+<CaseTableTabs series="iPhone 16" material="Clear Case" />

--- a/content/iphone/x.mdx
+++ b/content/iphone/x.mdx
@@ -1,6 +1,4 @@
 import CaseTableTabs from "../../components/CaseTableTabs";
-import CaseTable from "../../components/CaseTable";
-import VerticalCarousel from "../../components/VerticalCarousel";
 
 # iPhone X & XS cases
 
@@ -13,84 +11,38 @@ Contents under ~~pressure~~ development…
 - iPhone X cases are almost compatible with iPhone Xs, but it only fits if you are brave enough.
 - Neither of them is compatible with accessories for iPhone 11 Pro.
 
-## Summer 2019
+## iPhone Xs lineup
 
 ### Silicone Case
 
-<CaseTableTabs series="iPhone Xs" season="Summer 2019" material="Silicone Case" />
-
-## Spring 2019
-
-### Silicone Case
-
-<CaseTableTabs series="iPhone Xs" season="Spring 2019" material="Silicone Case" />
+<CaseTableTabs series="iPhone Xs" material="Silicone Case" />
 
 ### Leather Case
 
-<CaseTableTabs series="iPhone Xs" season="Spring 2019" material="Leather Case" />
+<CaseTableTabs series="iPhone Xs" material="Leather Case" />
 
 ### Leather Folio
 
-<CaseTableTabs series="iPhone Xs" season="Spring 2019" material="Leather Folio" />
+<CaseTableTabs series="iPhone Xs" material="Leather Folio" />
 
-## November 2018 / Sudden Drop
+### Smart Battery Case
+
+<CaseTableTabs series="iPhone Xs" material="Smart Battery Case" />
+
+Pink Sand released as part of Spring 2019 drop
+
+## iPhone X lineup
 
 ### Silicone Case
 
-<CaseTableTabs series="iPhone Xs" season="November 2018" material="Silicone Case" />
-
-## Autumn 2018 / iPhone Xs collection
-
-### Silicone Case
-
-<CaseTableTabs series="iPhone Xs" season="Autumn 2018" material="Silicone Case" />
+<CaseTableTabs series="iPhone X" material="Silicone Case" />
 
 ### Leather Case
 
-<CaseTableTabs series="iPhone Xs" season="Autumn 2018" material="Leather Case" />
+<CaseTableTabs series="iPhone X" material="Leather Case" />
 
 ### Leather Folio
-
-<CaseTableTabs series="iPhone Xs" season="Autumn 2018" material="Leather Folio" />
-
-## Summer 2018
-
-### Silicone Case
-
-<VerticalCarousel model="iPhone X" season="Summer 2018" material="Silicone Case" />
-
-## Spring 2018
-
-### Silicone Case
-
-<VerticalCarousel model="iPhone X" season="Spring 2018" material="Silicone Case" />
-
-### Leather Case
-
-<VerticalCarousel model="iPhone X" season="Spring 2018" material="Leather Case" />
-
-### Leather Folio
-
-<VerticalCarousel model="iPhone X" season="Spring 2018" material="Leather Folio" />
 
 (PRODUCT)RED Folio released slightly later, on an absolutely random date — April 9th, 2018
 
-## Autumn 2017 / iPhone X collection
-
-### Silicone Case
-
-<VerticalCarousel model="iPhone X" season="Autumn 2017" material="Silicone Case" />
-
-### Leather Case
-
-<VerticalCarousel model="iPhone X" season="Autumn 2017" material="Leather Case" />
-
-### Leather Folio
-
-<VerticalCarousel model="iPhone X" season="Autumn 2017" material="Leather Folio" />
-
-## Smart Battery Case
-
-<CaseTableTabs series="iPhone Xs" season="November 2018" material="Smart Battery Case" />
-
-Pink Sand released as part of Spring 2019 drop
+<CaseTableTabs series="iPhone X" material="Leather Folio" />

--- a/content/iphone/xr.mdx
+++ b/content/iphone/xr.mdx
@@ -1,5 +1,4 @@
 import CaseTableTabs from "../../components/CaseTableTabs";
-import VerticalCarousel from "../../components/VerticalCarousel";
 
 # Accessories for iPhone XR & 11
 
@@ -31,14 +30,4 @@ Cases designed for the iPhone 11 are compatible with both the iPhone 11 and iPho
 
 ## iPhone 11 Silicone Cases
 
-### Autumn 2019
-
-<VerticalCarousel model="iPhone 11" season="Autumn 2019" material="Silicone Case" />
-
-### Spring 2020
-
-<VerticalCarousel model="iPhone 11" season="Spring 2020" material="Silicone Case" />
-
-### Summer 2020
-
-<VerticalCarousel model="iPhone 11" season="Summer 2020" material="Silicone Case" />
+<CaseTableTabs series={["iPhone 11"]} material="Silicone Case" />


### PR DESCRIPTION
## Summary
- update the case table tabs to aggregate data by material across all seasons and drop the season filter
- expose the season for each case entry inside the vertical carousel display, including the loading skeleton
- collapse per-season content pages into single material sections for the iPhone catalog pages

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904c6cbf9c08322a602c4b6b00e8a9f